### PR TITLE
yubiswitch on: skip errors

### DIFF
--- a/main.c
+++ b/main.c
@@ -142,12 +142,12 @@ void callback_on(char *yubikey) {
 	fd = open("/sys/bus/usb/drivers/usbhid/bind", O_WRONLY);
 	if (fd < 0) {
 		perror("opening unbind");
-		exit(1);
+		return;
 	}
 	retval = write(fd, yubikey, strlen(yubikey));
 	if (retval < 0) {
 		perror("writing bind");
-		exit(1);
+		return;
 	}
 	close(fd);
 }


### PR DESCRIPTION
Skip errors when running `yubiswitch on`. In my scenario, the important bug was the last of three, and the 2nd bus was giving errors. So `yubiswitch on` would exit with error on 2nd bus and never enable the 3rd.
